### PR TITLE
missing set `logContentSliceRuleLogicJsonString` when  agent pull configuraton

### DIFF
--- a/agent-manager/agent-manager-extends/agent-manager-thirdpart/src/main/java/com/didichuxing/datachannel/agentmanager/thirdpart/agent/collect/configuration/extension/impl/DefaultAgentCollectConfigurationManageServiceExtensionImpl.java
+++ b/agent-manager/agent-manager-extends/agent-manager-thirdpart/src/main/java/com/didichuxing/datachannel/agentmanager/thirdpart/agent/collect/configuration/extension/impl/DefaultAgentCollectConfigurationManageServiceExtensionImpl.java
@@ -98,6 +98,7 @@ public class DefaultAgentCollectConfigurationManageServiceExtensionImpl implemen
         logCollectTaskConfiguration.setLogCollectTaskType(logCollectTask.getLogCollectTaskType());
         logCollectTaskConfiguration.setOldDataFilterType(logCollectTask.getOldDataFilterType());
         logCollectTaskConfiguration.setFileNameSuffixMatchRuleLogicJsonString(logCollectTask.getFileNameSuffixMatchRuleLogicJsonString());
+        logCollectTaskConfiguration.setLogContentSliceRuleLogicJsonString(logCollectTask.getLogContentSliceRuleLogicJsonString());
         if (CollectionUtils.isEmpty(logCollectTask.getDirectoryLogCollectPathList()) && CollectionUtils.isEmpty(logCollectTask.getFileLogCollectPathList())) {
             throw new ServiceException(
                     String.format("LogCollectTask={id=%d}关联的目录型采集路径集 & 文件型采集路径集不可都为空", logCollectTask.getId()),


### PR DESCRIPTION
missing set `logContentSliceRuleLogicJsonString` when  agent pull configuraton