### PR TITLE
Fix bug missing slice rule & fix a bug that kafka producer use wrong value serializer

### DIFF
--- a/agent-manager/agent-manager-core/src/main/java/com/didichuxing/datachannel/agentmanager/core/agent/configuration/impl/DefaultAgentCollectConfigurationManageServiceExtensionImpl.java
+++ b/agent-manager/agent-manager-core/src/main/java/com/didichuxing/datachannel/agentmanager/core/agent/configuration/impl/DefaultAgentCollectConfigurationManageServiceExtensionImpl.java
@@ -92,6 +92,7 @@ public class DefaultAgentCollectConfigurationManageServiceExtensionImpl implemen
         logCollectTaskConfiguration.setLogCollectTaskType(logCollectTask.getLogCollectTaskType());
         logCollectTaskConfiguration.setOldDataFilterType(logCollectTask.getOldDataFilterType());
         logCollectTaskConfiguration.setFileNameSuffixMatchRuleLogicJsonString(logCollectTask.getFileNameSuffixMatchRuleLogicJsonString());
+        logCollectTaskConfiguration.setLogContentSliceRuleLogicJsonString(logCollectTask.getLogContentSliceRuleLogicJsonString());
         if (CollectionUtils.isEmpty(logCollectTask.getDirectoryLogCollectPathList()) && CollectionUtils.isEmpty(logCollectTask.getFileLogCollectPathList())) {
             throw new ServiceException(
                     String.format("LogCollectTask={id=%d}关联的目录型采集路径集 & 文件型采集路径集不可都为空", logCollectTask.getId()),

--- a/log-agent/log-agent-sink/src/main/java/com/didichuxing/datachannel/agent/sink/kafkaSink/KafkaMessageProducer.java
+++ b/log-agent/log-agent-sink/src/main/java/com/didichuxing/datachannel/agent/sink/kafkaSink/KafkaMessageProducer.java
@@ -117,7 +117,7 @@ public class KafkaMessageProducer {
         confProperties.put("key.serializer",
             "org.apache.kafka.common.serialization.StringSerializer");
         confProperties.put("value.serializer",
-            "org.apache.kafka.common.serialization.StringSerializer");
+            "org.apache.kafka.common.serialization.ByteArraySerializer");
         confProperties.remove("serializer.class");
 
         // 兼容ack参数


### PR DESCRIPTION
fix bug for missing set `logContentSliceRuleLogicJsonString` when agent pull configuration
fix a bug that kafka producer use wrong value serializer